### PR TITLE
Handle binary files in reconstruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This packaged document includes a comprehensive directory structure, file conten
 - **.gitignore Integration:** Honors .gitignore files, letting you exclude specific files or directories.
 - **Output Splitting:** Can split the output into multiple files if the generated document exceeds a specified size.
 - **Flexible Modes:** Optionally generate structure-only documentation or include file contents.
+- **Codebase Reconstruction:** Rebuild a directory and its files from a dirdoc-generated Markdown document. Binary files are recreated as empty placeholders.
 
 
 ## Example Output
@@ -177,6 +178,11 @@ dirdoc --help
 - **Include .git folders in the documentation:**
   ```bash
   dirdoc --include-git /path/to/dir
+  ```
+
+- **Reconstruct a codebase from documentation:** Binary files will be restored as empty files.
+  ```bash
+  dirdoc --reconstruct -o ./restored project_documentation.md
   ```
 
 ## Use Cases

--- a/src/reconstruct.c
+++ b/src/reconstruct.c
@@ -1,0 +1,117 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "reconstruct.h"
+#include "dirdoc.h" // for MAX_PATH_LEN and BUFFER_SIZE
+
+static int mkdirs(const char *path) {
+    char tmp[MAX_PATH_LEN];
+    snprintf(tmp, sizeof(tmp), "%s", path);
+    size_t len = strlen(tmp);
+    if (len == 0)
+        return 0;
+    if (tmp[len - 1] == '/')
+        tmp[len - 1] = '\0';
+    for (char *p = tmp + 1; *p; p++) {
+        if (*p == '/') {
+            *p = '\0';
+            mkdir(tmp, 0755);
+            *p = '/';
+        }
+    }
+    return mkdir(tmp, 0755); // final component
+}
+
+static int is_fence_start(const char *line, int *len) {
+    int i = 0;
+    while (line[i] == '`') i++;
+    if (i >= 3) {
+        *len = i;
+        return 1;
+    }
+    return 0;
+}
+
+static int is_fence_end(const char *line, int len) {
+    for (int i = 0; i < len; i++) {
+        if (line[i] != '`') return 0;
+    }
+    char c = line[len];
+    return c == '\n' || c == '\0' || c == '\r';
+}
+
+int reconstruct_from_markdown(const char *md_path, const char *out_dir) {
+    FILE *in = fopen(md_path, "r");
+    if (!in) {
+        fprintf(stderr, "Error: cannot open %s\n", md_path);
+        return 1;
+    }
+
+    char line[BUFFER_SIZE];
+    char file_path[MAX_PATH_LEN];
+    FILE *out = NULL;
+    int in_code = 0;
+    int fence_len = 0;
+    int skip_file = 0;
+
+    while (fgets(line, sizeof(line), in)) {
+        if (!in_code && strncmp(line, "### 📄 ", 8) == 0) {
+            if (out) {
+                fclose(out);
+                out = NULL;
+            }
+            skip_file = 0;
+            line[strcspn(line, "\r\n")] = '\0';
+            snprintf(file_path, sizeof(file_path), "%s/%s", out_dir, line + 9);
+            char dir[MAX_PATH_LEN];
+            snprintf(dir, sizeof(dir), "%s", file_path);
+            char *p = strrchr(dir, '/');
+            if (p) {
+                *p = '\0';
+                mkdirs(dir);
+            } else {
+                mkdirs(out_dir);
+            }
+            out = fopen(file_path, "w");
+            continue;
+        }
+
+        if (!in_code) {
+            if (is_fence_start(line, &fence_len)) {
+                in_code = 1;
+                if (out) ftruncate(fileno(out), 0); // ensure empty before writing
+                continue;
+            }
+        } else {
+            if (is_fence_end(line, fence_len)) {
+                in_code = 0;
+                if (out) {
+                    fclose(out);
+                    out = NULL;
+                }
+                continue;
+            }
+            if (out && !skip_file) {
+                if (strncmp(line, "*Binary file*", 13) == 0 || strncmp(line, "*Error", 6) == 0) {
+                    /* Leave an empty file in place of binary or errored files */
+                    skip_file = 1;
+                    if (out) {
+                        fclose(out);
+                        out = NULL;
+                    }
+                    continue;
+                }
+                fputs(line, out);
+            }
+        }
+    }
+
+    if (out)
+        fclose(out);
+    fclose(in);
+    return 0;
+}
+

--- a/src/reconstruct.h
+++ b/src/reconstruct.h
@@ -1,0 +1,19 @@
+#ifndef RECONSTRUCT_H
+#define RECONSTRUCT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Reconstructs a directory from a dirdoc generated markdown file.
+ * md_path: path to the documentation markdown
+ * out_dir: directory to create reconstructed files
+ * Returns 0 on success, non-zero on failure.
+ */
+int reconstruct_from_markdown(const char *md_path, const char *out_dir);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RECONSTRUCT_H */

--- a/tests/test_dirdoc.c
+++ b/tests/test_dirdoc.c
@@ -21,6 +21,7 @@ void test_smart_split();
 void run_tiktoken_tests();
 void run_split_tests();
 int run_file_deletion_tests(void);
+void run_reconstruct_tests();
 
 #ifndef MAX_PATH_LEN
 #define MAX_PATH_LEN 4096
@@ -704,6 +705,7 @@ int main(int argc, char *argv[]) {
     run_tiktoken_tests();
     run_split_tests();
     run_file_deletion_tests();
+    run_reconstruct_tests();
     
     printf("✅ All tests passed!\n");
 

--- a/tests/test_reconstruct.c
+++ b/tests/test_reconstruct.c
@@ -1,0 +1,71 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "reconstruct.h"
+
+/* Functions from test_dirdoc.c */
+char *create_temp_dir();
+int remove_directory_recursive(const char *path);
+
+void test_reconstruct_basic() {
+    const char *md = "example_project/example_project_documentation.md";
+    char *out_dir = create_temp_dir();
+    int ret = reconstruct_from_markdown(md, out_dir);
+    assert(ret == 0);
+
+    char path[512];
+    snprintf(path, sizeof(path), "%s/src/example_main.c", out_dir);
+    FILE *f = fopen(path, "r");
+    assert(f != NULL);
+    char line[64];
+    fgets(line, sizeof(line), f);
+    fclose(f);
+    assert(strstr(line, "/*") != NULL);
+
+    remove_directory_recursive(out_dir);
+    free(out_dir);
+    printf("✔ test_reconstruct_basic passed\n");
+}
+
+void test_reconstruct_binary_placeholder() {
+    const char *markdown =
+        "# Directory Documentation:\n\n"
+        "### \xF0\x9F\x93\x84 bin/file.bin\n\n"
+        "```\n"
+        "*Binary file*\n"
+        "```\n";
+
+    char *out_dir = create_temp_dir();
+    char md_path[512];
+    snprintf(md_path, sizeof(md_path), "%s/doc.md", out_dir);
+    FILE *md = fopen(md_path, "w");
+    assert(md != NULL);
+    fputs(markdown, md);
+    fclose(md);
+
+    int ret = reconstruct_from_markdown(md_path, out_dir);
+    assert(ret == 0);
+
+    char path[512];
+    snprintf(path, sizeof(path), "%s/bin/file.bin", out_dir);
+    FILE *f = fopen(path, "r");
+    assert(f != NULL);
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fclose(f);
+    assert(size == 0);
+
+    remove_directory_recursive(out_dir);
+    free(out_dir);
+    printf("✔ test_reconstruct_binary_placeholder passed\n");
+}
+
+void run_reconstruct_tests() {
+    printf("Running reconstruct tests...\n");
+    test_reconstruct_basic();
+    test_reconstruct_binary_placeholder();
+    printf("All reconstruct tests passed!\n");
+}


### PR DESCRIPTION
## Summary
- leave empty placeholder files when reconstructing binary entries
- document new behavior in README
- test reconstructing binary placeholder

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6843607ead448323b727c7793e0be04b