### PR TITLE
Port makefiles toward BSD compatibility

### DIFF
--- a/example_project/example_Makefile
+++ b/example_project/example_Makefile
@@ -9,7 +9,7 @@ BINDIR = bin
 
 # Source files and object files
 SRCS = $(SRCDIR)/main.c $(SRCDIR)/utils.c
-OBJS = $(patsubst $(SRCDIR)/%.c,$(OBJDIR)/%.o,$(SRCS))
+OBJS = ${SRCS:${SRCDIR}/%.c=${OBJDIR}/%.o}
 
 # Target executable
 TARGET = $(BINDIR)/sample_app


### PR DESCRIPTION
## Summary
- replace GNU-only make functions with portable patterns
- drop GNU order-only prereqs

## Testing
- `make clean`
- `make -j$(nproc) all`
- `make test`
- `bmake clean` *(fails: "don't know how to make build/a.o")*
- `bmake -j$(nproc) all` *(fails: "don't know how to make build/a.o")*

------
https://chatgpt.com/codex/tasks/task_e_684d2b650c648323bb0e7df321896671